### PR TITLE
Fix `lib` submodule clone by specifying public URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib"]
 	path = lib
-	url = git@github.com:JCash/voronoi.git
+	url = https://github.com/JCash/voronoi

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install
 Download the contents of this git repository into Godot's module folder and re-build Godot.
 The module folder needs to be named `voronoi`, otherwise Godot won't compile properly.
 
-`git clone https://github.com/rakai93/godot_voronoi.git voronoi`
+`git clone https://github.com/rakai93/godot_voronoi.git voronoi --recurse-submodules`
 
 Example usage
 -----------------


### PR DESCRIPTION
Closes #7.

I think this is due to `git@` protocol which requires write access.